### PR TITLE
fix(entitybrowser): use entity class schema binding to avoid crashes

### DIFF
--- a/src/imgui/panels/entitybrowser/entitybrowser.cpp
+++ b/src/imgui/panels/entitybrowser/entitybrowser.cpp
@@ -21,6 +21,7 @@
 #include <imgui.h>
 #include <schemasystem/schemasystem.h>
 #include <entity2/entitysystem.h>
+#include <entity2/entityclass.h>
 #include "cs2_sdk/entity/cbaseentity.h"
 #include "type_stringifier.h"
 #include <format>
@@ -93,23 +94,27 @@ void Draw(bool* isOpen)
 		auto pEntity = g_pSelectedEntity.Get();
 		if (pEntity)
 		{
+			auto pEntityClass = GameEntitySystem() ? GameEntitySystem()->FindClassByDesignName(pEntity->GetClassname()) : nullptr;
+			auto pSchemaBinding = (pEntityClass && pEntityClass->m_pClassInfo) ? pEntityClass->GetSchemaBinding() : nullptr;
+
 			ImGui::Text("Classname: %s", pEntity->GetClassname());
 			ImGui::Text("Index: %d", pEntity->GetEntityIndex());
-			ImGui::Text("Schema: %s", pEntity->Schema_DynamicBinding().Get()->m_pszName);
+			ImGui::Text("Schema: %s", pSchemaBinding && pSchemaBinding->m_pszName ? pSchemaBinding->m_pszName : "N/A");
 			g_menuContext.m_propertyFilter.Draw("Search");
 
 			if (ImGui::BeginTable("Schema", 3, ImGuiTableFlags_Borders))
 			{
-
 				ImGui::TableSetupColumn("Name");
 				ImGui::TableSetupColumn("Type");
 				ImGui::TableSetupColumn("Value");
 				ImGui::TableHeadersRow();
 
-				auto pSchema = pEntity->Schema_DynamicBinding().Get();
-				std::unordered_map<std::string, std::string> overrideMap;
+				if (pSchemaBinding)
+				{
+					std::unordered_map<std::string, std::string> overrideMap;
 
-				DumpEntitySchema(pEntity, pSchema, overrideMap, true);
+					DumpEntitySchema(pEntity, pSchemaBinding, overrideMap, true);
+				}
 
 				ImGui::EndTable();
 			}
@@ -125,7 +130,7 @@ void Draw(bool* isOpen)
 
 void DumpEntitySchema(void* pSchemaField, CSchemaClassInfo* pSchema, std::unordered_map<std::string, std::string>& overrideMap, bool root)
 {
-	if (!pSchemaField)
+	if (!pSchemaField || !pSchema)
 		return;
 
 	ImGui::TableNextRow();


### PR DESCRIPTION
## Summary

This fixes a crash in the Entity Browser caused by resolving schema information through `CEntityInstance::Schema_DynamicBinding()`.

The crash was reproduced from generated dump files and consistently pointed to `GUI::EntityBrowser::Draw` in `src/imgui/panels/entitybrowser/entitybrowser.cpp` while rendering the selected entity's schema information.

## Root Cause

The selected entity handle itself was still valid, but `Schema_DynamicBinding().Get()` could return an invalid pointer on current CS2 builds.

From the dump analysis:
- Crash location: `src/imgui/panels/entitybrowser/entitybrowser.cpp`
- Call stack: `GUI::EntityBrowser::Draw -> GUI::DrawMainWindow -> GUI::InitializeGUI`
- Faulting access: dereferencing a bogus schema pointer
- Example invalid value: `0xccccccffcf0ebbe9`

Because the returned pointer was not `nullptr`, a simple null check was not enough to make this path safe.

## Changes

- Replaced schema lookup in `EntityBrowser::Draw()`:
  - old path: `pEntity->Schema_DynamicBinding().Get()`
  - new path: `GameEntitySystem()->FindClassByDesignName(pEntity->GetClassname())->GetSchemaBinding()`
- Kept the existing UI behavior, but resolved schema data through `CEntityClass`, which is stable in this case
- Added an extra defensive null check in `DumpEntitySchema()` so schema traversal is skipped safely when no schema is available

## Why This Fix

`CEntityHandle::Get()` already validates the selected entity handle through the entity system, so the entity itself was not the direct problem.

The unstable part was the per-entity dynamic schema lookup. Resolving schema from the entity class metadata avoids that path and prevents the crash while still providing the same schema browser output.

## Validation

- Built successfully in debug mode
- Reproduced the original crash with dump analysis through `cdb`
- Verified that the Entity Browser no longer crashes after switching to class-based schema resolution
<img width="1874" height="786" alt="cs2servergui_fix_entityBroswer" src="https://github.com/user-attachments/assets/f425d416-820f-4657-9da2-e6efb2033834" />

